### PR TITLE
Changed the .small style class line-height

### DIFF
--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -83,5 +83,5 @@ small {
   color: $lightText;
   font-weight: 500;
   letter-spacing: 1px;
-  line-height: 12px;
+  line-height: 18px;
 }


### PR DESCRIPTION
Changed the .small style class line-height:
Previous { line-height: 12px; }
Updated { line-height: 18px; }

Screenshot of how the spacing between lines was very tight when line-height was set at 12px: https://s33.postimg.cc/f00qushsv/Screen_Shot_2018-07-25_at_4.57.12_PM.png